### PR TITLE
Load and evaluate all javascript in Java

### DIFF
--- a/src/main/java/org/zalando/tessellate/transform4j/Nashorn.java
+++ b/src/main/java/org/zalando/tessellate/transform4j/Nashorn.java
@@ -15,17 +15,20 @@ class Nashorn {
   }
 
   static Object executeFunction(String filePath, String functionName, Object... args) throws NashornException {
+    return executeFunction(new String[]{filePath}, functionName, args);
+  }
+
+  static Object executeFunction(String[] filePaths, String functionName, Object... args) throws NashornException {
     ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
 
     if (engine == null) {
       throw new RuntimeException("Nashorn engine not available.");
     }
 
-    ClassLoader loader = Thread.currentThread().getContextClassLoader();
-    Reader reader = new InputStreamReader(loader.getResourceAsStream(filePath));
-
     try {
-      engine.eval(reader);
+      for (String filePath : filePaths) {
+        eval(engine, filePath);
+      }
     } catch (ScriptException e) {
       throw new NashornException(e.getMessage(), e);
     }
@@ -39,5 +42,11 @@ class Nashorn {
     } catch (NoSuchMethodException e) {
       throw new NashornException("No such function: " + functionName, e);
     }
+  }
+
+  private static void eval(ScriptEngine engine, String filePath) throws ScriptException {
+    ClassLoader loader = Thread.currentThread().getContextClassLoader();
+    Reader reader = new InputStreamReader(loader.getResourceAsStream(filePath));
+    engine.eval(reader);
   }
 }

--- a/src/main/java/org/zalando/tessellate/transform4j/Tessellate.java
+++ b/src/main/java/org/zalando/tessellate/transform4j/Tessellate.java
@@ -4,7 +4,10 @@ package org.zalando.tessellate.transform4j;
  * Main tessellate-transform4j class.
  */
 public class Tessellate {
-  private static final String SCRIPT_FILE = "index.js";
+  private static final String[] SCRIPTS = {
+      "tessellate.js", // tessellate-transform library
+      "index.js"       // tessellate-transform4j JavaScript API
+  };
   private static final String JS_FUNCTION = "transform";
   private static final String FILE_EXTENSION = ".json";
 
@@ -38,7 +41,7 @@ public class Tessellate {
   public static String transform(String json, Options options, int space) throws TransformException {
     try {
       File file = new File(json, FILE_EXTENSION);
-      return (String) Nashorn.executeFunction(SCRIPT_FILE, JS_FUNCTION, file, options, space);
+      return (String) Nashorn.executeFunction(SCRIPTS, JS_FUNCTION, file, options, space);
     } catch (Nashorn.NashornException e) {
       throw new TransformException(e.getMessage(), e.getCause());
     }

--- a/src/main/resources/index.js
+++ b/src/main/resources/index.js
@@ -1,4 +1,7 @@
-load('classpath:tessellate.js')
+/**
+ * tessellate-transform4j JavaScript API.
+ * Requires tessellate-transform as 'Tessellate' in the global context.
+ */
 
 function toNativeArray(items) {
   var array = []


### PR DESCRIPTION
Do not use load() inside javascript. This can cause problems depending
on the classloader that Nashorn uses under the hood. Instead load and
evaluate all javascript beforehand directly in Java.

Fixes ValidationError when using tessellate-transform4j in other projects together with Maven.
